### PR TITLE
docs: bootstrap codex guardrails and templates

### DIFF
--- a/.codex/GUARDRAILS.md
+++ b/.codex/GUARDRAILS.md
@@ -1,0 +1,14 @@
+Hard stops:
+- No dependency or CI changes without “Allow infra changes: yes”.
+- No deletion of public exports without deprecation note + test updates.
+- No content/schema changes without migration plan.
+- No secrets/tokens in code or examples.
+
+Quality gates:
+- Lint + Prettier pass.
+- Unit/integration tests updated; UI stories compile.
+- Accessibility: interactive elements labeled; headings hierarchical.
+
+Change etiquette:
+- Keep diffs minimal and scoped to the task.
+- If a broad refactor is beneficial, propose it in summary; do not execute unless the task permits it.

--- a/.codex/OUTPUT_FORMAT.md
+++ b/.codex/OUTPUT_FORMAT.md
@@ -1,0 +1,24 @@
+# Output Format
+
+Option A: Unified Diff (preferred)
+```diff
+--- a/path/to/file.ext
++++ b/path/to/file.ext
+@@
+- old line
++ new line
+```
+
+Option B: File Blocks (if diffs are impractical)
+```
+<entire new file content>
+```
+
+Epilogue
+
+- Files changed:
+  - path/to/file.ext
+- Tests added/updated:
+  - path/to/test.ext
+- Notes:
+  - Any decisions or follow-ups.

--- a/.codex/REPO_MAP.txt
+++ b/.codex/REPO_MAP.txt
@@ -1,0 +1,41 @@
+.
+├── .codex
+│   ├── GUARDRAILS.md
+│   ├── OUTPUT_FORMAT.md
+│   └── REPO_MAP.txt
+├── .env.example
+├── .github
+│   ├── ISSUE_TEMPLATE
+│   │   └── codex-task.md
+│   └── PULL_REQUEST_TEMPLATE.md
+├── .gitignore
+├── README.md
+├── app
+│   ├── api
+│   │   ├── chat
+│   │   │   └── route.ts
+│   │   ├── content
+│   │   │   └── route.ts
+│   │   └── speech
+│   │       └── route.ts
+│   ├── globals.css
+│   ├── layout.tsx
+│   └── page.tsx
+├── components
+│   └── TerminalResume.tsx
+├── docs
+│   ├── ARCHITECTURE.md
+│   ├── CONTENT_SCHEMA.md
+│   ├── COPY_TONE.md
+│   └── STYLEGUIDE.md
+├── next-env.d.ts
+├── next.config.js
+├── package-lock.json
+├── package.json
+├── postcss.config.js
+├── public
+│   └── package.json
+├── tailwind.config.js
+└── tsconfig.json
+
+12 directories, 27 files

--- a/.github/ISSUE_TEMPLATE/codex-task.md
+++ b/.github/ISSUE_TEMPLATE/codex-task.md
@@ -1,0 +1,29 @@
+name: Codex Task
+about: Structured task for Codex
+title: "[codex] <concise goal>"
+labels: ["codex"]
+body:
+  - type: textarea
+    id: goal
+    attributes: { label: Goal, description: Outcome and user impact }
+  - type: textarea
+    id: context
+    attributes: { label: Context, description: Links to docs/ and prior issues }
+  - type: textarea
+    id: constraints
+    attributes: { label: Constraints, description: Tech limits, banned changes }
+  - type: textarea
+    id: files
+    attributes: { label: Files to touch, description: Exact paths Codex may edit }
+  - type: textarea
+    id: acceptance
+    attributes: { label: Done criteria, description: Tests, metrics, UX states }
+  - type: dropdown
+    id: infra
+    attributes:
+      label: Allow infra changes
+      options: [no, yes]
+    validations: { required: true }
+  - type: textarea
+    id: output
+    attributes: { label: Output format, value: "Use .codex/OUTPUT_FORMAT.md (Diff preferred)" }

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## What
+Concise summary of the change
+
+## Why
+Link to issue / goal
+
+## How to test
+Steps + expected outcomes
+
+## Screenshots
+(If UI)
+
+## Checklist
+- [ ] Lints & tests pass
+- [ ] Stories updated (if UI)
+- [ ] No infra changes unless allowed
+
+* @jlossner

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # lossner.tech
-Professional portfolio website with terminal interface
+
+This repository powers Joshua Lossner’s personal website (**lossner.tech**).
+
+## What this repo is optimized for
+- **Codex-first** workflows: tasks are provided as structured prompts; Codex produces small, testable diffs.
+- **Static-first** site using Next.js (App Router), MDX content, and TailwindCSS.
+- **Clear guardrails**: see `.codex/` and `docs/`.
+
+## Quick start
+- Read `docs/ARCHITECTURE.md` and `docs/CONTENT_SCHEMA.md`
+- For Codex tasks, use `.github/ISSUE_TEMPLATE/codex-task.md`
+- Repo map: `.codex/REPO_MAP.txt` (regenerate: `tree -I 'node_modules|.git|.next|build' > .codex/REPO_MAP.txt`)
+
+## Branches
+- `main` → production (Vercel)
+- `test` → preview
+
+## Conventions
+- See `docs/STYLEGUIDE.md` (code) and `docs/COPY_TONE.md` (site text).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,17 @@
+# Architecture (lossner.tech)
+
+- Framework: Next.js (App Router), MDX content, TailwindCSS
+- Content source: `/content` with frontmatter schema (see docs/CONTENT_SCHEMA.md)
+- Deploy: Vercel (prod: main, preview: test)
+
+## Invariants
+- Static-first; no server DB. API routes only if strictly necessary (e.g., contact form).
+- Page metadata derives from content frontmatter.
+- Design system lives in `/components/ui` with tokens in `tailwind.config.ts`.
+
+## Routing
+- App Router under `/app`
+- Shared layout and metadata per route segment
+
+## Content
+- All resume/writings use frontmatter defined in `docs/CONTENT_SCHEMA.md`.

--- a/docs/CONTENT_SCHEMA.md
+++ b/docs/CONTENT_SCHEMA.md
@@ -1,0 +1,22 @@
+# Content Schema
+
+## Frontmatter: /content/resume/entries/*.md
+- type: "job" | "education" | "project"
+- title: string
+- startDate: YYYY-MM
+- endDate: YYYY-MM | "present"
+- tags: string[]
+- summary: string
+- bullets: string[]
+- slug: string (unique)
+
+Validation:
+- If endDate != "present", endDate >= startDate.
+
+## Frontmatter: /content/posts/*.mdx
+- title: string
+- slug: string
+- date: YYYY-MM-DD
+- tags: string[]
+- summary: string
+- hero?: string (path under /public)

--- a/docs/COPY_TONE.md
+++ b/docs/COPY_TONE.md
@@ -1,0 +1,6 @@
+# Copy & Tone
+
+- Clear, human, low-jargon
+- Prefer active verbs and short sentences
+- Headings ≤ 6 words where possible
+- Keep personal but professional voice across the site

--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -1,0 +1,7 @@
+# Code Style
+
+- TypeScript strict; no implicit any
+- Named exports; barrels only in `/lib`
+- Tailwind utility-first; prefer `gap-*` over margins for spacing
+- Commit style: feat|fix|docs|refactor|chore(scope): message
+- Tests required for code changes; stories for UI components


### PR DESCRIPTION
## What
- add repository guardrails, output format instructions, and repo map
- add docs for architecture, content schema, style, and tone
- add Codex issue and pull request templates

## Why
- prepare repo for LLM-friendly collaboration

## How to test
- `npm test` (fails: Missing script "test")
- `npm run lint` (asks to configure ESLint)


------
https://chatgpt.com/codex/tasks/task_e_68a51b0832b88326bca880f3f7a551a8