### PR TITLE
chore(analytics): add Vercel Web Analytics and wire <Analytics/> in root layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,10 @@ This repository powers Joshua Lossner’s personal website (**lossner.tech**).
 
 ## Conventions
 - See `docs/STYLEGUIDE.md` (code) and `docs/COPY_TONE.md` (site text).
+
+## Web Analytics
+
+- Enable Analytics in Vercel → Project → Analytics → Enable.
+- Deploy (or redeploy) to activate routes under /_vercel/insights/*.
+- Verify in devtools Network tab you see /_vercel/insights/view requests on page load.
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,6 +15,7 @@ export default function RootLayout({
     <html lang="en">
       <body>
         {children}
+        {/* Vercel Web Analytics: see requests to /_vercel/insights/view after deploy */}
         <Analytics />
       </body>
     </html>


### PR DESCRIPTION
## Summary
- document how to enable Vercel Web Analytics
- comment and render `<Analytics />` in the root layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(requires interactive ESLint setup)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a53919e5b0832699afd76476f49b08